### PR TITLE
Fixed tabs move (for FF17+), and added tabs copy.

### DIFF
--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -361,7 +361,9 @@ VTTabbrowserTabs.prototype = {
     _patchedMethods: ["_positionPinnedTabs",
                       "_getDropIndex",
                       "_isAllowedForDataTransfer",
-                      "_setEffectAllowedForDataTransfer"
+                      "_setEffectAllowedForDataTransfer",
+                      "_animateTabMove",
+                      "_finishAnimateTabMove",
                       ],
     swapMethods: function swapMethods() {
         const tabs = this.tabs;
@@ -426,7 +428,7 @@ VTTabbrowserTabs.prototype = {
                     return dt.effectAllowed = "none";
                 }
 
-                return dt.effectAllowed = "copyMove";
+                return dt.effectAllowed = event.ctrlKey ? "copy" : "move";
             }
         }
 
@@ -435,6 +437,24 @@ VTTabbrowserTabs.prototype = {
             return dt.effectAllowed = dt.dropEffect = "link";
         }
         return dt.effectAllowed = "none";
+    },
+
+    // This function is supposed to show an animation while the tab is being
+    // moved (not copied), and to update the tab drop index.
+    _animateTabMove: function(event) {
+        // Save the drop index here, because the drop handler won't move
+        // the tab without that.
+        let draggedTab = event.dataTransfer.mozGetDataAt(TAB_DROP_TYPE, 0);
+        draggedTab._dragData.animDropIndex = this._getDropIndex(event);
+
+        // We don't show a particular animation, because doing so seems to 
+        // break some add-ons. I guess this is the same reason why
+        // the "dragover" event handler is disabled. -- Tey'
+    },
+
+    _finishAnimateTabMove: function() {
+        // TODO we might want to do something here. For now we just
+        // don't do anything which is better than doing something stupid.
     },
 
     // Calculate the drop indicator's position for vertical tabs.

--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -350,12 +350,12 @@ VTTabbrowserTabs.prototype = {
     init: function() {
         this.swapMethods();
         this.onDragOver = this.onDragOver.bind(this);
-        tabs.addEventListener('dragover', this.onDragOver, false);
+        this.tabs.addEventListener('dragover', this.onDragOver, false);
     },
 
     unload: function() {
         this.swapMethods();
-        tabs.removeEventListener('dragover', this.onDragOver, false);
+        this.tabs.removeEventListener('dragover', this.onDragOver, false);
     },
 
     _patchedMethods: ["_positionPinnedTabs",
@@ -447,9 +447,16 @@ VTTabbrowserTabs.prototype = {
         let draggedTab = event.dataTransfer.mozGetDataAt(TAB_DROP_TYPE, 0);
         draggedTab._dragData.animDropIndex = this._getDropIndex(event);
 
-        // We don't show a particular animation, because doing so seems to 
-        // break some add-ons. I guess this is the same reason why
-        // the "dragover" event handler is disabled. -- Tey'
+        // Show the drop indicator, which will be positioned in our "dragover" handler.
+        this._tabDropIndicator.collapsed = false;
+
+        /* TODO: it would be better if the drop indicator were different for copy and move (a
+         *       different color for instance).
+         *       In Mozilla implementation, the tab indicator is only used for copy, and an
+         *       animation is used for move (the tabs are shifted in the tab bar as the mouse drags
+         *       the tab to be moved).
+         *       I have no idea how to implement such an animation tough. -- Tey'
+         */
     },
 
     _finishAnimateTabMove: function() {
@@ -476,7 +483,7 @@ VTTabbrowserTabs.prototype = {
         }
 
         newMargin += ind.clientHeight / 2;
-        ind.style.MozTransform = "translate(0, " + Math.round(newMargin) + "px)";
+        ind.style.transform = "translate(0, " + Math.round(newMargin) + "px)";
         ind.style.MozMarginStart = null;
         ind.style.marginTop = null;
         ind.style.maxWidth = rect.width + "px";


### PR DESCRIPTION
This commit fixes the moving of tabs with FireFox 17+, and adds (fixes ?) the possibility to copy tabs through drag'n'drop.

Please, consider adding it to the master branch.

On a side note, I tried to fix the drop indicator animation, but, even though it worked flawlessly with my test profile, it seems to break (at least) one add-on with the profile I use for my day to day browsing (probably "Tab Utilities Lite" or "TabGroups Menu").
