### PR TITLE
set linux.css as default style sheet

### DIFF
--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -72,9 +72,10 @@ VerticalTabs.prototype = {
           case "Darwin":
             this.installStylesheet("resource://verticaltabs/skin/osx/osx.css");
             break;
-          case "Linux":
+          default:
             this.installStylesheet("resource://verticaltabs/skin/linux/linux.css");
             break;
+        }
         }
 
         this.rearrangeXUL();


### PR DESCRIPTION
This extension didn't work correctly on BSD without default skin style.
