### PR TITLE
Fix margin for toolbar on OS X.

### DIFF
--- a/skin/osx/osx.css
+++ b/skin/osx/osx.css
@@ -1,9 +1,8 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 #nav-bar {
-    margin-left: 60px;
-    margin-right: 22px;
-    margin-top: -22px;
+    margin: 0;
+    padding: 0;
     background-image: none !important;
     background-color: transparent !important;
 }


### PR DESCRIPTION
This doesn't look perfect, but at least it stops the URL bar being sliced in half, with excess padding on each end.
